### PR TITLE
Replace variable used for testing with actual value of BATT_ADC pin

### DIFF
--- a/emonTH_DHT22_DS18B20_RFM69CW_Pulse/emonTH_DHT22_DS18B20_RFM69CW_Pulse.ino
+++ b/emonTH_DHT22_DS18B20_RFM69CW_Pulse/emonTH_DHT22_DS18B20_RFM69CW_Pulse.ino
@@ -331,7 +331,7 @@ void loop()
     // 2. Change multiplier in line 353 Serial.print(emonth.battery/10.0);
     // 3. Change scales factor in the emonhub node decoder entry for the emonTH
     // See more https://community.openenergymonitor.org/t/emonth-battery-measurement-accuracy/1317
-    //emonth.battery=int(aread*3.222);
+    //emonth.battery=int(analogRead(BATT_ADC)*3.222);
 
     if (debug==1)
     {


### PR DESCRIPTION
I'm sorry. I forget to replace testing variable with actual value. This PR fixes problem introduced in this https://github.com/openenergymonitor/emonTH/pull/10 pr 